### PR TITLE
fix: use seconds from epoch in AssertionVerifierServiceImpl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 allprojects {
-	version = '1.0.0-RC6'
+	version = '1.0.0-RC7-hotfix'
 	group = 'it.pagopa.tech.lollipop-consumer-java-sdk'
 	sourceCompatibility = '11'
 	targetCompatibility = '11'

--- a/core/src/main/java/it/pagopa/tech/lollipop/consumer/service/impl/AssertionVerifierServiceImpl.java
+++ b/core/src/main/java/it/pagopa/tech/lollipop/consumer/service/impl/AssertionVerifierServiceImpl.java
@@ -222,7 +222,7 @@ public class AssertionVerifierServiceImpl implements AssertionVerifierService {
                     ErrorRetrievingIdpCertDataException.ErrorCode.ENTITY_ID_FIELD_NOT_FOUND,
                     "Missing entity id field in the retrieved saml assertion");
         }
-        instant = parseInstantToMillis(instant);
+        instant = parseInstantToUnixTimestamp(instant);
         try {
             entityId = entityId.trim();
             List<IdpCertData> idpCertData = idpCertProvider.getIdpCertData(instant, entityId);
@@ -436,11 +436,11 @@ public class AssertionVerifierServiceImpl implements AssertionVerifierService {
         return publicKey;
     }
 
-    private String parseInstantToMillis(String instant) {
+    private String parseInstantToUnixTimestamp(String instant) {
         try {
             instant =
                     Long.toString(
-                            ISODateTimeFormat.dateTimeParser().parseDateTime(instant).getMillis());
+                            ISODateTimeFormat.dateTimeParser().parseDateTime(instant).getMillis() / 1000);
         } catch (UnsupportedOperationException | IllegalArgumentException e) {
             String msg =
                     String.format(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

The parseInstantToMillis method has been renamed to parseInstantToUnixTimestamp, making sure that the returned value is divied by 1000.

<!--- Describe your changes in detail -->

#### Motivation and Context

Using millis format for IS tags make the Verifier use always fetch the latest value (since number is greatest).

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

Local tests have been run and pass.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] This update doesn't require a documentation update